### PR TITLE
Fix AttributeError when destroy is called

### DIFF
--- a/flask_kvsession.py
+++ b/flask_kvsession.py
@@ -100,7 +100,7 @@ class KVSession(CallbackDict, SessionMixin):
         for k in self.keys():
             del self[k]
 
-        if self.sid_s:
+        if getattr(self, 'sid_s', None):
             current_app.kvsession_store.delete(self.sid_s)
 
         self.modified = False


### PR DESCRIPTION
1. Set a session.
2. Update session with keys.
3. Destroy.
4. Check if destroy worked.
5. PROFIT
