### PR TITLE
The session cookie path is always '/' even when SESSION_COOKIE_PATH is set

### DIFF
--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -205,6 +205,7 @@ class KVSessionInterface(SessionInterface):
             response.set_cookie(key=app.config['SESSION_COOKIE_NAME'],
                                 value=cookie_data,
                                 expires=self.get_expiration_time(app, session),
+                                path=self.get_cookie_path(app),
                                 domain=self.get_cookie_domain(app),
                                 secure=app.config['SESSION_COOKIE_SECURE'],
                                 httponly=app.config['SESSION_COOKIE_HTTPONLY'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,8 @@ def store(request):
 def client(app):
     client = app.test_client()
 
-    def get_session_cookie(self):
-        return self.cookie_jar._cookies['localhost.local']['/']['session']
+    def get_session_cookie(self, path='/'):
+        return self.cookie_jar._cookies['localhost.local'][path]['session']
 
     client.get_session_cookie = six.create_bound_method(
         get_session_cookie, client,

--- a/tests/test_flask_kvsession.py
+++ b/tests/test_flask_kvsession.py
@@ -355,3 +355,20 @@ def test_existing_session_not_modified(client):
     client.get('/store-in-session/k1/value1/')
     rv = client.get('/is-modified-session/')
     assert rv.data == b('False')
+
+
+def test_path_app_root(app, client):
+    app.config['APPLICATION_ROOT'] = '/foo'
+
+    client.get('/store-in-session/k1/value1/')
+    cookie = client.get_session_cookie('/foo')
+    assert cookie.path == '/foo'
+
+
+def test_path_session_path(app, client):
+    app.config['APPLICATION_ROOT'] = '/foo'
+    app.config['SESSION_COOKIE_PATH'] = '/bar'
+
+    client.get('/store-in-session/k1/value1/')
+    cookie = client.get_session_cookie('/bar')
+    assert cookie.path == '/bar'


### PR DESCRIPTION
While getting started with Flask-KVSession I noticed that the session cookie path was always set to __/__ even when _APPLICATION_ROOT_ or _SESSION_COOKIE_PATH_ was set in the application config. This should fix the issue.