### PR TITLE
miniature fix for python 2.6

### DIFF
--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -190,7 +190,7 @@ class KVSessionInterface(SessionInterface):
             if getattr(store, 'ttl_support', False):
                 # TTL is supported
                 #workaround for python 2.6 in timedelta.total_seconds
-                td = current_apppermanent_session_lifetime
+                td = current_app.permanent_session_lifetime
                 ttl = td.seconds + (td.days * 24 * 3600)
                 store.put(session.sid_s, data, ttl)
             else:

--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -189,7 +189,9 @@ class KVSessionInterface(SessionInterface):
 
             if getattr(store, 'ttl_support', False):
                 # TTL is supported
-                ttl = current_app.permanent_session_lifetime.total_seconds()
+                #workaround for python 2.6 in timedelta.total_seconds
+                td = current_apppermanent_session_lifetime
+                ttl = td.seconds + (td.days * 24 * 3600)
                 store.put(session.sid_s, data, ttl)
             else:
                 store.put(session.sid_s, data)


### PR DESCRIPTION
When using AWS and EC2 you are forced to use python <2.7. But total_seconds was added to timedelta in that version. This code should absolutely fix this timedelta problem for backwards comparability.