### PR TITLE
Use App.permanent_session_lifetime to get the configured lifetime value.

### DIFF
--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -148,7 +148,7 @@ class KVSessionInterface(SessionInterface):
                     sid = SessionID.unserialize(sid_s)
 
                     if sid.has_expired(
-                            app.config['PERMANENT_SESSION_LIFETIME']):
+                            app.permanent_session_lifetime):
                         # we reach this point if a "non-permanent" session has
                         # expired, but is made permanent. silently ignore the
                         # error with a new session
@@ -254,7 +254,7 @@ class KVSessionExtension(object):
 
                 # remove if expired
                 if sid.has_expired(
-                    app.config['PERMANENT_SESSION_LIFETIME'],
+                    app.permanent_session_lifetime,
                     now
                 ):
                     app.kvsession_store.delete(key)


### PR DESCRIPTION
Flask allows integer value in seconds or timedelta for PERMANENT_SESSION_LIFETIME  (changed in version 0.8). App.permanent_session_lifetime always returns timedelta based on the value.