### PR TITLE
Bypass has_expired check when session store supports TimeToLive

### DIFF
--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -145,11 +145,12 @@ class KVSessionInterface(SessionInterface):
                         session_cookie).decode('ascii')
                     sid = SessionID.unserialize(sid_s)
 
-                    if sid.has_expired(app.permanent_session_lifetime):
-                        # we reach this point if a "non-permanent" session has
-                        # expired, but is made permanent. silently ignore the
-                        # error with a new session
-                        raise KeyError
+                    if not getattr(current_app.kvsession_store, 'ttl_support', False):
+                        if sid.has_expired(app.permanent_session_lifetime):
+                            # we reach this point if a "non-permanent" session has
+                            # expired, but is made permanent. silently ignore the
+                            # error with a new session
+                            raise KeyError
 
                     # retrieve from store
                     s = self.session_class(self.serialization_method.loads(

--- a/tests/test_expiration.py
+++ b/tests/test_expiration.py
@@ -105,7 +105,7 @@ def test_redis_expiration_lifetime(
     ttl_3 = redis.ttl(sid_3)
     assert MY_TTL-1 <= ttl_3 <= MY_TTL
     
-    # wait once more, beyond t_0 
+    # wait once more, beyond t_0 + MY_TTL
     time.sleep(MY_TTL-1)
     # t = 2xMY_TTL + epsilon
     res_4 = redis_client.get('/store-in-session/k1/v1/')

--- a/tests/test_expiration.py
+++ b/tests/test_expiration.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import time
 
 from conftest import app as app_, client as client_
 import pytest
@@ -47,3 +48,67 @@ def test_redis_expiration_ephemeral_session(
     ttl = redis.ttl(sid)
 
     assert TEST_TTL-ttl <= 5
+
+def test_redis_expiration_lifetime(
+    redis, redis_store, redis_app, redis_client
+):
+    '''
+    check if the session expires according to
+    PERMANENT_SESSION_LIFETIME
+    '''
+
+    MY_TTL = 2
+    redis_app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(
+        seconds=MY_TTL
+    )
+
+    # t_0 = 0 seconds starts now
+    t_0 = time.time()
+    klist_0 = redis.keys()
+    res_0 = redis_client.get('/store-in-session/k1/v1/')
+
+    # t_1 = 0 + epsilon
+    assert res_0.headers.get('Set-Cookie') is not None
+    klist_1 = redis.keys()
+    assert len(klist_1) - len(klist_0) == 1
+    sid_1 = klist_1[0]
+    cookie_1 = res_0.headers.get('Set-Cookie')
+    ttl_1 = redis.ttl(sid_1)
+    assert ttl_1 <= MY_TTL
+
+    res_1 = redis_client.get('/store-in-session/k1/v1/')
+    assert cookie_1 == res_1.headers.get('Set-Cookie')
+
+    # initial session expired, key should evaporate
+    time.sleep(MY_TTL)
+    # t = MY_TTL + epsilon
+    klist_2 = redis.keys()
+    assert len(klist_2) == len(klist_0)
+
+    # t = MY_TTL + epsilon
+    # get a new session, cookie gets renewed
+    res_2 = redis_client.get('/store-in-session/k1/v1/')
+    cookie_2 = res_2.headers.get('Set-Cookie')
+    assert cookie_2 != cookie_1
+
+    # t = MY_TTL + epsilon
+    klist_3 = redis.keys()
+    sid_3 = klist_3[0]
+
+    # cookie does not get renewed, but session lifetime is extended
+    time.sleep(MY_TTL-1)
+    # t = 2xMY_TTL - 1 + epsilon
+    res_3 = redis_client.get('/store-in-session/k1/v1/')
+    assert res_3.headers.get('Set-Cookie') == cookie_2
+
+    # ttl should now be very close to original value, i.e. MY_TTL
+    ttl_3 = redis.ttl(sid_3)
+    assert MY_TTL-1 <= ttl_3 <= MY_TTL
+    
+    # wait once more, beyond t_0 
+    time.sleep(MY_TTL-1)
+    # t = 2xMY_TTL + epsilon
+    res_4 = redis_client.get('/store-in-session/k1/v1/')
+    # expect the cookie to still be alive
+    assert res_4.headers.get('Set-Cookie') == cookie_2
+    


### PR DESCRIPTION
(1 line change)
## motivation

_(was hoping this would help visitors searching for this issue)_

I'm using `RedisStore` and have trouble extending the session lifetime on visit.

Once `PERMANENT_SESSION_LIFETIME` is set for `RedisStore`, the data gets saved with `SETEX` so the expiration happens automatically. To my understanding, by design, if the store supports TTL, housekeeping functions like `cleanup_sessions` and even `SessionID.has_expired` can be ignored by the user for all practical purposes.
## issue

The code in https://github.com/mbr/flask-kvsession/blob/master/flask_kvsession/__init__.py#L148-L152 does the `has_expired` check based on deserialization of `KEY_CREATED`, so we end up ignoring the TTL set in `save_session` in https://github.com/mbr/flask-kvsession/blob/master/flask_kvsession/__init__.py#L183-L186
## proposed change

in `open_session`, check the `store` for TTL support prior to the `has_expired` check; if supported, bypass the `has_expired` check that relies on `KEY_CREATED`.
## impact

No regressions, and repeated visits apply session lifetime extension according to `PERMANENT_SESSION_LIFETIME`, though this change feels a bit hacky. Is it sensible?

Thanks!
