### PR TITLE
Support for (optionally) declaring the Pickle Protocol when writing to session store

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,9 @@ documentation), the following configuration settings are available:
 ``SESSION_SET_TTL``            Whether or not to set the time-to-live of the
                                session on the backend, if supported. Default
                                is ``True``.
+``SESSION_PICKLE_PROTOCOL``    The Pickling protocol to be used when storing
+                               the session on the backend. Default is set to
+                               the pickle module DEFAULT_PROTOCOL.
 ============================== ================================================
 
 

--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -177,7 +177,12 @@ class KVSessionInterface(SessionInterface):
                         app.config['SESSION_KEY_BITS'])).serialize()
 
             # save the session, now its no longer new (or modified)
-            data = self.serialization_method.dumps(dict(session))
+            if 'SESSION_PICKLE_PROTOCOL' in current_app.config:
+                # A Pickle Protocol was specified in the Flask app configuration so we will attempt to respect it.
+                data = self.serialization_method.dumps(dict(session),
+                                                       protocol=current_app.config['SESSION_PICKLE_PROTOCOL'])
+            else:
+                data = self.serialization_method.dumps(dict(session))
             store = current_app.kvsession_store
 
             if getattr(store, 'ttl_support', False):


### PR DESCRIPTION
Added support for explicitly declaring the Pickle Protocol. This is to support sharing a session between flask apps using different python versions (2 or 3).

This pull request is to fix a specific problem when you have two flask apps, one written in Python 2 and one written in Python 3 that shares a server-side session. Python 3 uses Pickle Protocol 3 by default, but Python 2 can only read from Pickle Protocol 2 or less.
