### PR TITLE
Enable support for SESSION_REFRESH_EACH_REQUEST

### DIFF
--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -8,7 +8,7 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle
-from datetime import datetime, timedelta
+from datetime import datetime
 from random import SystemRandom
 import re
 
@@ -85,8 +85,6 @@ class KVSession(CallbackDict, SessionMixin):
             d.modified = True
 
         CallbackDict.__init__(self, initial, _on_update)
-        if not initial:
-            self["t_expires"] = datetime.now() + timedelta(seconds=current_app.config["PERMANENT_SESSION_LIFETIME"])
 
     def destroy(self):
         """Destroys a session completely, by deleting all keys and removing it
@@ -147,9 +145,7 @@ class KVSessionInterface(SessionInterface):
                         session_cookie).decode('ascii')
                     sid = SessionID.unserialize(sid_s)
 
-                    refresh = app.config["SESSION_REFRESH_EACH_REQUEST"]
-
-                    if not refresh and sid.has_expired(app.permanent_session_lifetime):
+                    if sid.has_expired(app.permanent_session_lifetime):
                         # we reach this point if a "non-permanent" session has
                         # expired, but is made permanent. silently ignore the
                         # error with a new session
@@ -159,11 +155,6 @@ class KVSessionInterface(SessionInterface):
                     s = self.session_class(self.serialization_method.loads(
                         current_app.kvsession_store.get(sid_s)))
                     s.sid_s = sid_s
-
-                    if refresh and datetime.now() > s["t_expires"]:
-                        # the session has expired
-                        raise KeyError
-
                 except (BadSignature, KeyError):
                     # either the cookie was manipulated or we did not find the
                     # session in the backend.
@@ -184,11 +175,6 @@ class KVSessionInterface(SessionInterface):
                 session.sid_s = SessionID(
                     current_app.config['SESSION_RANDOM_SOURCE'].getrandbits(
                         app.config['SESSION_KEY_BITS'])).serialize()
-
-            # refresh the lifetime of a permanent session
-            refresh = app.config["SESSION_REFRESH_EACH_REQUEST"] and session.permanent
-            if refresh:
-                session["t_expires"] = self.get_expiration_time(app, session)
 
             # save the session, now its no longer new (or modified)
             data = self.serialization_method.dumps(dict(session))

--- a/flask_kvsession/__init__.py
+++ b/flask_kvsession/__init__.py
@@ -150,11 +150,13 @@ class KVSessionInterface(SessionInterface):
 
                     refresh = app.config["SESSION_REFRESH_EACH_REQUEST"]
 
-                    if not refresh and sid.has_expired(app.permanent_session_lifetime):
+                    if not refresh and sid.has_expired(
+                            app.permanent_session_lifetime):
                         # we reach this point if a "non-permanent" session has
                         # expired, but is made permanent. silently ignore the
                         # error with a new session
-                        logging.getLogger("KVSession").debug("Session expired (checked against session id)")
+                        logging.getLogger("KVSession").debug(
+                            "Session expired (checked against session id)")
                         raise KeyError
 
                     # retrieve from store
@@ -163,15 +165,22 @@ class KVSessionInterface(SessionInterface):
                                 current_app.kvsession_store.get(sid_s)))
                         s.sid_s = sid_s
                     except:
-                        logging.getLogger("KVSession").debug("Session not found in store")
+                        logging.getLogger("KVSession").debug(
+                            "Session not found in store")
                         raise KeyError
 
                     logging.getLogger("KVSession").debug("Session loaded")
                     if "t_expire" in s:
-                        if refresh and s.permanent and datetime.now() > s["t_expire"]:
-                            logging.getLogger("KVSession").debug("Session expired (checked against stored datetime)")
+                        if (refresh
+                                and s.permanent
+                                and datetime.now() > s["t_expire"]):
+                            logging.getLogger("KVSession").debug(
+                                "Session expired "
+                                "(checked against stored datetime)")
                             raise KeyError
-                        logging.getLogger("KVSession").debug("Session will expire at: {0}".format(s["t_expires"]))
+                        logging.getLogger("KVSession").debug(
+                            "Session will expire "
+                            "at: {0}".format(s["t_expires"]))
                 except (BadSignature, KeyError):
                     # either the cookie was manipulated or we did not find the
                     # session in the backend.
@@ -197,11 +206,14 @@ class KVSessionInterface(SessionInterface):
                     current_app.config['SESSION_RANDOM_SOURCE'].getrandbits(
                         app.config['SESSION_KEY_BITS'])).serialize()
                 # store expiration date
-                session["t_expires"] = datetime.now() + app.config["PERMANENT_SESSION_LIFETIME"]
+                session["t_expires"] = (datetime.now()
+                                        + app.config["PERMANENT_SESSION_LIFETIME"])
 
-            # if SESSION_REFRESH_EACH_REQUEST is True for a permanent session, update expiration date
+            # if SESSION_REFRESH_EACH_REQUEST is True for a permanent session,
+            # update expiration date
             if app.config["SESSION_REFRESH_EACH_REQUEST"] and session.permanent:
-                session["t_expires"] = datetime.now() + app.config["PERMANENT_SESSION_LIFETIME"]
+                session["t_expires"] = (datetime.now()
+                                        + app.config["PERMANENT_SESSION_LIFETIME"])
 
             # save the session, now its no longer new (or modified)
             data = self.serialization_method.dumps(dict(session))
@@ -216,7 +228,8 @@ class KVSessionInterface(SessionInterface):
 
             logging.getLogger("KVSession").debug("Session saved")
             if "t_expires" in session:
-                logging.getLogger("KVSession").debug("Session will expire at: {0}".format(session["t_expires"]))
+                logging.getLogger("KVSession").debug(
+                    "Session will expire at: {0}".format(session["t_expires"]))
 
             session.new = False
             session.modified = False


### PR DESCRIPTION
If `app.config["SESSION_REFRESH_EACH_REQUEST"]` is `True`, the expiration of permanent sessions is not checked against the creation date stored inside the session id, but against the "t_expires" field saved with a session in the store.

I also had to add some logging during development and decided to keep it around because it proved quite useful.