### PR TITLE
Update .travis.yml to work with current python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 env:
 - TOXENV=py27
-- TOXENV=py33
+- TOXENV=py35
+- TOXENV=py36
+- TOXENV=py37
+- TOXENV=py38
 install: pip install tox
 script: tox
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
-env:
-- TOXENV=py27
-- TOXENV=py35
-- TOXENV=py36
-- TOXENV=py37
-- TOXENV=py38
+matrix:
+  include:
+  - python: 3.8
+    env: TOXENV=py38
+  - python: 3.7
+    env: TOXENV=py37
+  - python: 3.6
+    env: TOXENV=py36
+  - python: 3.5
+    env: TOXENV=py35
+  - python: 2.7
+    env: TOXENV=py27
 install: pip install tox
 script: tox
 services:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,13 +36,12 @@ def store(request):
     if request.param == 'dict':
         return DictStore()
     elif request.param == 'redis':
-        return request.getfuncargvalue('redis_store')
+        return request.getfixturevalue('redis_store')
 
     assert False
 
 
-@pytest.fixture
-def client(app):
+def _client(app):
     client = app.test_client()
 
     def get_session_cookie(self, path='/'):
@@ -56,7 +55,11 @@ def client(app):
 
 
 @pytest.fixture
-def app(store):
+def client(app):
+    return _client(app)
+
+
+def _app(store):
     app = Flask(__name__)
 
     app.kvsession = KVSessionExtension(store, app)
@@ -133,3 +136,8 @@ def app(store):
         return 'PROFIT'
 
     return app
+
+
+@pytest.fixture
+def app(store):
+    return _app(store)

--- a/tests/test_expiration.py
+++ b/tests/test_expiration.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from conftest import app as app_, client as client_
+from conftest import _app, _client
 import pytest
 
 
@@ -9,12 +9,12 @@ TEST_TTL = 300
 
 @pytest.fixture
 def redis_app(redis_store):
-    return app_(redis_store)
+    return _app(redis_store)
 
 
 @pytest.fixture
 def redis_client(redis_app):
-    return client_(redis_app)
+    return _client(redis_app)
 
 
 def test_redis_expiration_permanent_session(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps=


### PR DESCRIPTION
When re-running the tests with current pytest versions there were also some errors caused by deprecations within pytest, so I fixed these as well to make the build pass again